### PR TITLE
Make ssh cloning atomic; handle creds more robustly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "directories",
  "git2",
  "sysinfo",
+ "uuid",
 ]
 
 [[package]]
@@ -67,6 +68,12 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
@@ -347,6 +354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +556,12 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -685,6 +714,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +743,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "4.5.49", features = ["derive"] }
 directories = "6.0.0"
 git2 = { version = "0.20.2", features = ["https", "ssh"] }
 sysinfo = "0.37.2"
+uuid = { version = "1.18.1", features = ["v4"] }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,9 +1,11 @@
 use clap::Parser;
 use git2::build::RepoBuilder;
 use git2::{Cred, FetchOptions, RemoteCallbacks};
+use std::env::temp_dir;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, exit};
+use uuid::Uuid;
 
 use crate::cli::common;
 
@@ -13,9 +15,9 @@ pub struct Args {
     #[arg()]
     name: String,
 
-    /// Remote source to pull environment from
+    /// Remote repository to pull environment from
     #[arg(long)]
-    source: Option<String>,
+    repository: Option<String>,
 }
 
 pub fn execute(args: Args) {
@@ -30,35 +32,75 @@ pub fn execute(args: Args) {
     // Check if the project already exists. If it does, exit
     let project_env_dir = araki_envs_dir.join(&args.name);
     if project_env_dir.exists() {
-        println!("Environment {:?} already exists!", &args.name);
+        eprintln!(
+            "Environment {:?} already exists! {project_env_dir:?}",
+            &args.name
+        );
         return;
     }
-    let _ = fs::create_dir_all(&project_env_dir);
 
-    if let Some(src) = args.source {
-        initialize_remote_git_project(src, &project_env_dir);
+    // Since initializing the env repository can fail in a number of different ways,
+    // we clone into a temporary directory first. If that's successful, we then move it to the
+    // target directory.
+    let temp_path = temp_dir().join(Uuid::new_v4().to_string());
+    if let Err(err) = fs::create_dir_all(&temp_path) {
+        eprintln!("Unable to initialize the repote repository at {temp_path:?}. Reason: {err}",);
+        exit(1);
+    }
+    if let Some(src) = args.repository {
+        initialize_remote_git_project(src, &temp_path);
     } else {
-        initialize_empty_project(&project_env_dir);
+        initialize_empty_project(&temp_path);
+    }
+    if fs::rename(&temp_path, &project_env_dir).is_err() {
+        eprintln!("Error writing environment to {project_env_dir:?}");
+        exit(1);
     }
 }
 
-pub fn initialize_remote_git_project(source: String, project_env_dir: &Path) {
-    println!("Pulling from remote source '{}'", source);
-    // TODO: validate source
+pub fn initialize_remote_git_project(repo: String, project_env_dir: &Path) {
+    println!("Pulling from remote repository '{}'", repo);
     let mut callbacks = RemoteCallbacks::new();
-    // TODO: allow user to configure their ssh key
-    callbacks.credentials(|_url, username_from_url, _allowed_types| {
-        Cred::ssh_key_from_agent(username_from_url.unwrap())
+
+    // Keep track of whether we've tried to get credentials from ssh-agent.
+    // See https://github.com/nodegit/nodegit/issues/1133 for an example of this, but it affects
+    // git2-rs as well; see https://github.com/rust-lang/git2-rs/issues/1140 and
+    // https://github.com/rust-lang/git2-rs/issues/347 for more context.
+    let mut tried_agent = false;
+
+    callbacks.credentials(|_url, username_from_url, allowed_types| {
+        let username = username_from_url.ok_or(git2::Error::from_str(
+            "Unable to get the ssh username from the URL.",
+        ))?;
+        if allowed_types.is_ssh_key() {
+            Cred::ssh_key_from_agent(username).inspect(|_| {
+                if tried_agent {
+                    eprintln!(
+                        "Unable to authenticate via ssh. Is ssh-agent running, and does it \
+                        have your git credentials?"
+                    );
+                    exit(1);
+                }
+                tried_agent = true
+            })
+        } else {
+            Err(git2::Error::from_str(
+                "araki only supports ssh for git interactions. Please \
+                    configure ssh-agent.",
+            ))
+        }
     });
+
     let mut fetch_opts = FetchOptions::new();
     fetch_opts.remote_callbacks(callbacks);
+
     let mut builder = RepoBuilder::new();
     builder.fetch_options(fetch_opts);
 
-    match builder.clone(&source, project_env_dir) {
-        Ok(repo) => repo,
-        Err(e) => panic!("Failed to clone '{}', error: {}", source, e), // TODO: better error checking, surely this should not panic
-    };
+    let _ = builder.clone(&repo, project_env_dir).map_err(|err| {
+        eprintln!("Failed to clone {repo}. Reason: {err}");
+        exit(1);
+    });
 
     // TODO: validate that the project has a valid project structure.
     // That means it has a
@@ -78,22 +120,24 @@ pub fn initialize_empty_project(project_env_dir: &Path) {
     let _ = Command::new("pixi")
         .arg("init")
         .current_dir(project_env_dir)
-        .output()
+        .status()
         .expect("Failed to execute command");
 
     // TODO: change this to use git2
     // Initialize the git repo
     let _ = Command::new("git")
         .arg("init")
+        .arg("-b")
+        .arg("main")
         .current_dir(project_env_dir)
-        .output()
+        .status()
         .expect("Failed to execute command");
 
     // Install the pixi project
     let _ = Command::new("pixi")
         .arg("install")
         .current_dir(project_env_dir)
-        .output()
+        .status()
         .expect("Failed to execute command");
 
     // Add initial git commit
@@ -101,12 +145,12 @@ pub fn initialize_empty_project(project_env_dir: &Path) {
         .arg("add")
         .arg(".")
         .current_dir(project_env_dir)
-        .output()
+        .status()
         .expect("Failed to execute command");
     let _ = Command::new("git")
         .arg("commit")
         .args(["-m", "\"Initial commit\""])
         .current_dir(project_env_dir)
-        .output()
+        .status()
         .expect("Failed to execute command");
 }


### PR DESCRIPTION
This PR

- Handles SSH credentials more robustly, fixing an issue where the CLI would hang if the user didn't have ssh-agent with a valid key
- Makes env repo cloning/initialization atomic, so that failures don't pollute `~/.araki/envs` with partially-initialized env directories
- Allows pixi and git commands being run under the hood to write to stdout

Closes #22.