### PR TITLE
Reuse existing machinery for pushing inside `araki push`

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -167,7 +167,7 @@ pub async fn execute(args: Args) {
         "{} Pushing changes to remote...",
         style("[4/4]").bold().dim(),
     );
-    common::git_push("origin", "main").unwrap_or_else(|err| {
+    common::git_push("origin", &["refs/heads/main"]).unwrap_or_else(|err| {
         eprintln!("Unable to push to remote: {err}");
         exit(1);
     });

--- a/src/common.rs
+++ b/src/common.rs
@@ -141,7 +141,7 @@ fn generate_remote_callbacks() -> RemoteCallbacks<'static> {
     callbacks
 }
 
-pub fn git_push(remote: &str, branch: &str) -> Result<(), git2::Error> {
+pub fn git_push(remote: &str, refs: &[&str]) -> Result<(), git2::Error> {
     let callbacks = generate_remote_callbacks();
 
     let mut push_options = PushOptions::new();
@@ -149,7 +149,7 @@ pub fn git_push(remote: &str, branch: &str) -> Result<(), git2::Error> {
     let repo =
         get_araki_git_repo().map_err(|err| git2::Error::from_str(format!("{err}").as_str()))?;
     let mut origin = repo.find_remote(remote)?;
-    origin.push(&[format!("refs/heads/{branch}")], Some(&mut push_options))?;
+    origin.push(refs, Some(&mut push_options))?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR makes the `araki push` command reuse git push machinery already implemented in the `common` module. Since `araki push` pushes both tags and `main`, I allowed arbitrary refspecs to be passed in to `common::git_push`. Closes #37.