### PR TITLE
Check project path has valid pixi project before setting up remote

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -56,15 +56,10 @@ pub async fn execute(args: Args) {
     }
 
     // Ensure the project has a pixi.toml and pixi.lock
-    for item in ["pixi.toml", "pixi.lock"] {
-        if !path.join(item).exists() {
-            eprintln!(
-                "Provided path does not have a valid pixi project. Ensure that pixi.toml and pixi.lock files exist on path"
-            );
-            exit(1);
-        }
+    if common::LockSpec::from_path(&path).is_err() {
+        eprintln!("No lockspec found at {path_str}");
+        exit(1);
     }
-
     // Create a new respository
     let backend = backends::get_current_backend().unwrap_or_else(|err| {
         eprintln!("Unable to get the current backend: {err}");


### PR DESCRIPTION
Currently when running `araki init` for a path that does not have a valid lockspec, araki will create a remote repo and pull it locally before failing. If the user creates a lockspec in the path and then retries to `araki init`, araki will produce an error about the remote repository already existing. 

This PR checks that the local project is valid before taking initialization steps. 

In the future it might be better to be able to fully roll back a set of dependent actions if one fails.