### PR TITLE
Demo: Allow pushing/pulling/checking out individual commits 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod checkout;
 pub mod clone;
+pub mod commit;
 pub mod init;
 pub mod list;
 pub mod pull;

--- a/src/cli/checkout.rs
+++ b/src/cli/checkout.rs
@@ -16,12 +16,24 @@ pub fn execute(args: Args) {
         exit(1);
     });
 
-    let git_ref = if args.tag == "latest" {
-        repo.find_reference("refs/heads/main")
-            .expect("No tag found")
+    let tag = args.tag;
+
+    let git_ref = if tag == "latest" {
+        match repo.find_reference("refs/heads/main") {
+            Ok(res ) => res,
+            Err(_err) => {
+                eprintln!("Unable to find the latest commit at refs/heads/main");
+                exit(1);
+            }
+        }
     } else {
-        repo.find_reference(&format!("refs/tags/{}", args.tag))
-            .expect("No tag found")
+        match repo.find_reference(&format!("refs/tags/{}", tag)) {
+            Ok(res ) => res,
+            Err(_err) => {
+                eprintln!("{}", format!("Could not find tag '{}'", tag));
+                exit(1);
+            }
+        }
     };
 
     let git_ref_object = git_ref.peel(git2::ObjectType::Commit).unwrap();

--- a/src/cli/checkout.rs
+++ b/src/cli/checkout.rs
@@ -21,7 +21,7 @@ pub fn execute(args: Args) {
 
     let git_ref_object = if tag == "latest" {
         match repo.find_reference("refs/heads/main") {
-            Ok(res ) => res.peel(git2::ObjectType::Commit).unwrap(),
+            Ok(res) => res.peel(git2::ObjectType::Commit).unwrap(),
             Err(_err) => {
                 eprintln!("Unable to find the latest commit at refs/heads/main");
                 exit(1);
@@ -29,12 +29,13 @@ pub fn execute(args: Args) {
         }
     } else {
         match repo.find_reference(&format!("refs/tags/{}", tag)) {
-            Ok(res ) => res.peel(git2::ObjectType::Commit).unwrap(),
+            Ok(res) => res.peel(git2::ObjectType::Commit).unwrap(),
             Err(_err) => {
-                match repo.find_object(Oid::from_str(&tag).unwrap(), Some(git2::ObjectType::Commit)) {
+                match repo.find_object(Oid::from_str(&tag).unwrap(), Some(git2::ObjectType::Commit))
+                {
                     Ok(r) => r,
                     Err(_err) => {
-                        eprintln!("{}", format!("Could not find tag '{}'", tag));
+                        eprintln!("Could not find tag '{}'", tag);
                         exit(1);
                     }
                 }

--- a/src/cli/checkout.rs
+++ b/src/cli/checkout.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use git2::Oid;
 use std::process::{Command, exit};
 
 use crate::common;
@@ -6,8 +7,8 @@ use crate::common;
 #[derive(Parser, Debug, Default)]
 pub struct Args {
     // name of the tag
-    #[arg(help = "Name of the tag")]
-    tag: String,
+    #[arg(help = "Name of the tag or commit")]
+    tag_or_commit: String,
 }
 
 pub fn execute(args: Args) {
@@ -16,11 +17,11 @@ pub fn execute(args: Args) {
         exit(1);
     });
 
-    let tag = args.tag;
+    let tag = args.tag_or_commit;
 
-    let git_ref = if tag == "latest" {
+    let git_ref_object = if tag == "latest" {
         match repo.find_reference("refs/heads/main") {
-            Ok(res ) => res,
+            Ok(res ) => res.peel(git2::ObjectType::Commit).unwrap(),
             Err(_err) => {
                 eprintln!("Unable to find the latest commit at refs/heads/main");
                 exit(1);
@@ -28,15 +29,19 @@ pub fn execute(args: Args) {
         }
     } else {
         match repo.find_reference(&format!("refs/tags/{}", tag)) {
-            Ok(res ) => res,
+            Ok(res ) => res.peel(git2::ObjectType::Commit).unwrap(),
             Err(_err) => {
-                eprintln!("{}", format!("Could not find tag '{}'", tag));
-                exit(1);
+                match repo.find_object(Oid::from_str(&tag).unwrap(), Some(git2::ObjectType::Commit)) {
+                    Ok(r) => r,
+                    Err(_err) => {
+                        eprintln!("{}", format!("Could not find tag '{}'", tag));
+                        exit(1);
+                    }
+                }
             }
         }
     };
 
-    let git_ref_object = git_ref.peel(git2::ObjectType::Commit).unwrap();
     let commit = git_ref_object
         .as_commit()
         .ok_or_else(|| git2::Error::from_str("Tag did not peel to a commit"))

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -7,7 +7,6 @@ use crate::common;
 
 #[derive(Parser, Debug, Default)]
 pub struct Args {
-
     #[arg(short, long, help = "Commit message")]
     message: String,
 
@@ -49,7 +48,7 @@ pub fn execute(args: Args) {
         Some("HEAD"),      // Update the HEAD reference
         &signature,        // Author
         &signature,        // Committer
-        &args.message,         // Commit message
+        &args.message,     // Commit message
         &tree,             // Tree containing the staged changes
         &[&parent_commit], // Parent commit(s)
     )
@@ -68,7 +67,7 @@ pub fn execute(args: Args) {
         }
 
         repo.tag(
-            &tag,
+            tag,
             &head,
             &signature,
             &tag_message,

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -1,0 +1,79 @@
+use clap::Parser;
+use git2::Signature;
+use std::path::Path;
+use std::process::exit;
+
+use crate::common;
+
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+
+    #[arg(short, long, help = "Commit message")]
+    message: String,
+
+    // name of the tag
+    #[arg(short, long, help = "Tag the commit with name")]
+    tag: Option<String>,
+
+    #[arg(short, long, help = "Description of the tag")]
+    describe_tag: Option<String>,
+}
+
+pub fn execute(args: Args) {
+    let repo = common::get_araki_git_repo().unwrap_or_else(|err| {
+        eprintln!("Couldn't recognize the araki repo: {err}");
+        exit(1);
+    });
+
+    let mut index = repo.index().expect("Failed to get index");
+
+    // Add files
+    index
+        .add_path(Path::new("pixi.toml"))
+        .expect("unable to add pixi.toml");
+    index
+        .add_path(Path::new("pixi.lock"))
+        .expect("unable to add pixi.lock");
+    index.write().expect("Failed to write index");
+
+    let tree_oid = index.write_tree().expect("failed to write tree");
+    let tree = repo.find_tree(tree_oid).expect("failed to find tree");
+    let signature = Signature::now("araki", "place@holder.com").expect("failed to get signature");
+    let head = repo.head().expect("Failed to get HEAD");
+    let parent_commit = repo
+        .find_commit(head.target().expect("Failed to get HEAD target OID"))
+        .expect("Failed to find parent commit");
+
+    // Commit change
+    repo.commit(
+        Some("HEAD"),      // Update the HEAD reference
+        &signature,        // Author
+        &signature,        // Committer
+        &args.message,         // Commit message
+        &tree,             // Tree containing the staged changes
+        &[&parent_commit], // Parent commit(s)
+    )
+    .expect("Failed to create commit");
+
+    if let Some(ref tag) = args.tag {
+        // Create tag
+        // Get the OID of the commit to tag (e.g., HEAD)
+        let head = repo.revparse_single("HEAD").expect("unable to find HEAD");
+
+        let tag_message: String;
+        if let Some(ref message) = args.describe_tag {
+            tag_message = message.to_string();
+        } else {
+            tag_message = format!("araki environment tag: {}", tag)
+        }
+
+        repo.tag(
+            &tag,
+            &head,
+            &signature,
+            &tag_message,
+            false, // Set to false for an annotated tag, true for a lightweight tag
+        )
+        .expect("Unable to tag");
+    }
+}

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -27,7 +27,7 @@ pub fn execute(args: Args) {
             .expect("Failed to execute command");
         let tree_stdout = String::from_utf8_lossy(&tree_output.stdout);
         println!("{}", tree_stdout);
-    } else if args.tags { 
+    } else if args.tags {
         let tags = repo.tag_names(Some("*")).unwrap();
 
         for name_w in tags.iter() {
@@ -49,7 +49,9 @@ pub fn execute(args: Args) {
 
         // Optional: set the sorting order (default is reverse chronological by time)
         // You can use Sort::TOPOLOGICAL or combine flags like Sort::TIME | Sort::REVERSE
-        revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE).unwrap();
+        revwalk
+            .set_sorting(Sort::TOPOLOGICAL | Sort::REVERSE)
+            .unwrap();
 
         // Iterate over the commit OIDs (Object IDs) returned by the walker
         for oid in revwalk {
@@ -60,7 +62,9 @@ pub fn execute(args: Args) {
 
             // Extract commit information
             let author = commit.author();
-            let summary_bytes = commit.summary_bytes().unwrap_or_else(|| commit.message_bytes());
+            let summary_bytes = commit
+                .summary_bytes()
+                .unwrap_or_else(|| commit.message_bytes());
             let summary = str::from_utf8(summary_bytes).unwrap_or("Invalid UTF-8 message");
 
             println!(
@@ -71,7 +75,6 @@ pub fn execute(args: Args) {
                 summary,
             );
         }
-
     }
 }
 

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -21,17 +21,13 @@ pub fn execute(args: Args) {
         let tags = repo.tag_names(Some("*")).unwrap();
 
         for name_w in tags.iter() {
-            tag_refs.push( format!("refs/tags/{}", &name_w.unwrap()) );
+            tag_refs.push(format!("refs/tags/{}", &name_w.unwrap()));
         }
         tag_refs.push("refs/heads/main".to_string());
 
         let v2: Vec<&str> = tag_refs.iter().map(|s| &**s).collect();
 
-        common::git_push(
-            "origin",
-            v2.as_slice(),
-        )
-        .unwrap_or_else(|err| {
+        common::git_push("origin", v2.as_slice()).unwrap_or_else(|err| {
             eprintln!("Unable to push to remote: {err}");
             exit(1);
         })

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -7,19 +7,45 @@ use crate::common;
 pub struct Args {
     /// name of the tag
     #[arg()]
-    tag: String,
+    tag: Option<String>,
 }
 
 pub fn execute(args: Args) {
-    common::git_push(
-        "origin",
-        &[
-            "refs/heads/main",
-            format!("refs/tags/{}", args.tag).as_str(),
-        ],
-    )
-    .unwrap_or_else(|err| {
-        eprintln!("Unable to push to remote: {err}");
+    let repo = common::get_araki_git_repo().unwrap_or_else(|err| {
+        eprintln!("Couldn't recognize the araki repo: {err}");
         exit(1);
-    })
+    });
+
+    if args.tag.is_none() {
+        let mut tag_refs: Vec<String> = Vec::new();
+        let tags = repo.tag_names(Some("*")).unwrap();
+
+        for name_w in tags.iter() {
+            tag_refs.push( format!("refs/tags/{}", &name_w.unwrap()) );
+        }
+        tag_refs.push("refs/heads/main".to_string());
+
+        let v2: Vec<&str> = tag_refs.iter().map(|s| &**s).collect();
+
+        common::git_push(
+            "origin",
+            v2.as_slice(),
+        )
+        .unwrap_or_else(|err| {
+            eprintln!("Unable to push to remote: {err}");
+            exit(1);
+        })
+    } else {
+        common::git_push(
+            "origin",
+            &[
+                "refs/heads/main",
+                format!("refs/tags/{}", args.tag.unwrap()).as_str(),
+            ],
+        )
+        .unwrap_or_else(|err| {
+            eprintln!("Unable to push to remote: {err}");
+            exit(1);
+        })
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use crate::cli::auth;
 use crate::cli::checkout;
 use crate::cli::clone;
+use crate::cli::commit;
 use crate::cli::init;
 use crate::cli::list;
 use crate::cli::pull;
@@ -35,6 +36,9 @@ pub enum Command {
 
     /// Clone a lockspec from a remote repository and install it in the current directory
     Clone(clone::Args),
+
+    /// Commit a change to an environment
+    Commit(commit::Args),
 
     /// Create a new araki-managed lockspec from an existing lockspec
     Init(init::Args),
@@ -69,6 +73,7 @@ pub async fn main() {
             Command::Auth(cmd) => auth::execute(cmd).await,
             Command::Checkout(cmd) => checkout::execute(cmd),
             Command::Clone(cmd) => clone::execute(cmd),
+            Command::Commit(cmd) => commit::execute(cmd),
             Command::Init(cmd) => init::execute(cmd).await,
             Command::List(cmd) => list::execute(cmd),
             Command::Pull(cmd) => pull::execute(cmd),


### PR DESCRIPTION
ref: https://github.com/openteams-ai/araki/issues/42

Currently, araki only supports tagging changes to an environment. This PR demos how araki might work if it is able to use git commits in addition to tags. It adds the following features:

* Add 'araki commit' command. This command allows users to commit a change to the repo without tagging.
* List commits and tags
  * `araki list` will list all the commits in the project 
  * `araki list --tags` will list all the tags in the project 
* checkout tags or commits
* pushes all tags + commits by default. Also able to push all commits + a selected tag.